### PR TITLE
Adjusting case on DXTokenRegistry imports

### DIFF
--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,5 +1,5 @@
 const Migrations = artifacts.require("Migrations");
-const DxTokenRegistry = artifacts.require("dxTokenRegistry");
+const DxTokenRegistry = artifacts.require("DXTokenRegistry");
 
 module.exports = function(deployer) {
   deployer.deploy(Migrations);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
-var DXTokenRegistry = artifacts.require("./dxTokenRegistry.sol");
+var DXTokenRegistry = artifacts.require("DXTokenRegistry");
 
 module.exports = function(deployer){
   deployer.deploy(DXTokenRegistry);
-}
+};

--- a/test/TestDxTokenRegistry.js
+++ b/test/TestDxTokenRegistry.js
@@ -1,6 +1,6 @@
 
 const truffleAssert = require("truffle-assertions");
-const tokenRegistry = artifacts.require("./dxTokenRegistry.sol");
+const tokenRegistry = artifacts.require("DXTokenRegistry");
 
 contract("dxTokenRegistry", async (accounts) => {
     let __contract;


### PR DESCRIPTION
Due to the case, I was not able to run `truffle tests` nor `truffle migrate`:

```
» truffle test
Using network 'development'.


Compiling your contracts...
===========================
> Everything is up to date, there is nothing to compile.

/home/alfeto/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/cli.bundled.js:369947
        throw new Error("Could not find artifacts for " + import_path + " from any sources");
        ^

Error: Could not find artifacts for dxTokenRegistry from any sources
    at Resolver.require (/home/alfeto/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/cli.bundled.js:369947:15)
    at TestResolver.require (/home/alfeto/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/cli.bundled.js:357445:30)
    at Object.require (/home/alfeto/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/cli.bundled.js:211138:38)
    at ResolverIntercept.require (/home/alfeto/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/cli.bundled.js:461654:32)
    at /home/alfeto/work/TCR/migrations/1_initial_migration.js:2:35
    at Script.runInContext (vm.js:133:20)
    at Script.runInNewContext (vm.js:139:17)
    at Object.file (/home/alfeto/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/cli.bundled.js:361559:12)
    at Migration._load (/home/alfeto/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/cli.bundled.js:459943:24)
    at process._tickCallback (internal/process/next_tick.js:68:7)
Truffle v5.1.23 (core: 5.1.23)
Node v10.18.0
```

Now:

```
» truffle test
Using network 'development'.


Compiling your contracts...
===========================
> Everything is up to date, there is nothing to compile.



  Contract: dxTokenRegistry
    ✓ should set deployer as owner
    ✓ should not allow non-admins to add lists (62ms)
    ✓ should allow admins to add lists (162ms)
    ✓ should not allow non-admins to add tokens (73ms)
    ✓ should allow admins to add tokens (129ms)
    ✓ should revert duplicate tokens (123ms)
    ✓ should revert invalid listId (57ms)
    ✓ should remove tokens (125ms)
    ✓ should revert transaction when trying to remove inactive tokens (60ms)
    ✓ should transfer ownership (85ms)


  10 passing (1s)

```