### PR TITLE
Added `view` modifier to `getTokenIndex` to satisfy compiler warning

### DIFF
--- a/contracts/dxTokenRegistry.sol
+++ b/contracts/dxTokenRegistry.sol
@@ -123,7 +123,7 @@ contract DXTokenRegistry is Ownable {
     /// @param _listId ID of list to get tokens from.
     /// @param _token Token address to check.
     /// @return index position of given token address in list.
-    function getTokenIndex(uint256 _listId, address _token) internal returns (uint256) {
+    function getTokenIndex(uint256 _listId, address _token) internal view returns (uint256) {
         for (uint256 i = 0; i < tcrs[_listId].tokens.length; i++) {
             if (tcrs[_listId].tokens[i] == _token) {
                 return i;


### PR DESCRIPTION
Before:

```
» truffle compile

Compiling your contracts...
===========================
> Compiling ./contracts/dxTokenRegistry.sol
> Compilation warnings encountered:

    /home/alfeto/work/TCR/contracts/dxTokenRegistry.sol:126:5: Warning: Function state mutability can be restricted to view
    function getTokenIndex(uint256 _listId, address _token) internal returns (uint256) {
    ^ (Relevant source part starts here and spans across multiple lines).

> Artifacts written to /home/alfeto/work/TCR/build/contracts
> Compiled successfully using:
   - solc: 0.6.2+commit.bacdbe57.Emscripten.clang
```

After:
```
 » truffle compile

Compiling your contracts...
===========================
> Compiling ./contracts/dxTokenRegistry.sol
> Artifacts written to /home/alfeto/work/TCR/build/contracts
> Compiled successfully using:
   - solc: 0.6.2+commit.bacdbe57.Emscripten.clang
```